### PR TITLE
rename traefik entrypoints to the less confusing web and websecure

### DIFF
--- a/traefik.yml.in
+++ b/traefik.yml.in
@@ -1,8 +1,8 @@
 # vim: ft=yaml ts=2 sw=2 et:
 entryPoints:
-  http:
+  web:
     address: :80
-  https:
+  websecure:
     address: :443
     http:
       tls:


### PR DESCRIPTION
instead of http and https

Signed-off-by: Nagy Károly Gábriel <k@jpi.io>